### PR TITLE
destroyのtransactionが効いていなかったのを修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -639,7 +639,6 @@ sequelize.sync().then(() => {
                         where: {
                             userName,
                         },
-                    }, {
                         transaction: t,
                     })
                     .then((result) => {


### PR DESCRIPTION
destroyの引数指定を間違えていて、transactionが効いていなかったので修正。destroyは1引数(option)のみ受け取る

Fixes #7 