### PR TITLE
レターペア一括登録を高速化するために、(文字, 単語)のカウントをSQLで算出

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 require('dotenv').config();
-const _ = require('lodash');
 const bodyParser = require('body-parser');
 const crypto = require('crypto');
 const express = require('express');
@@ -400,7 +399,7 @@ sequelize.sync().then(() => {
         LetterPair.findAll(query).then((tmpResult) => {
             // ユーザ名をマスク
             const result = tmpResult.map(elm => {
-                const plainElm = elm.get({ plain: true });
+                const plainElm = elm.get({ plain: true, });
 
                 // sha256に変換し、最初の8桁のみ採用
                 // 複数のユーザで同じ値になることはほぼ無いはず
@@ -421,6 +420,8 @@ sequelize.sync().then(() => {
             res.status(400).send(badRequestError);
         });
     });
+
+    app.get(process.env.EXPRESS_ROOT + '/letterPairCount', route.letterPairCount.getProcess);
 
     // 直近28日(envファイルで指定)の中で、直近の mean of 3 を計算
     app.get(process.env.EXPRESS_ROOT + '/letterPairQuizLog/:userName', (req, res, next) => {

--- a/src/route/index.js
+++ b/src/route/index.js
@@ -4,3 +4,5 @@ exports.memoLogMemorization = require('./memoLogMemorization');
 exports.memoLogRecall = require('./memoLogRecall');
 exports.memoScore = require('./memoScore');
 exports.memoTrial = require('./memoTrial');
+
+exports.letterPairCount = require('./letterPairCount');

--- a/src/route/letterPairCount.js
+++ b/src/route/letterPairCount.js
@@ -1,0 +1,41 @@
+const { sequelize, } = require('../model');
+const path = require('path');
+const { getBadRequestError, } = require('../lib/utils');
+
+const LetterPair = sequelize.import(path.join(__dirname, '../model/letterPair'));
+
+// レターペア一括登録を高速化するために、(letters, words)ごとのカウントをSQLで算出
+const getProcess = (req, res, next) => {
+    const query = {
+        attributes: [
+            'letters',
+            'word',
+            [ sequelize.fn('count', sequelize.col('*')), 'userCount', ],
+        ],
+        group: [
+            'letters',
+            'word',
+        ],
+        order: [
+            [ sequelize.fn('count', sequelize.col('*')), 'DESC', ],
+        ],
+    };
+
+    return LetterPair
+        .findAll(query)
+        .then((result) => {
+            const ans = {
+                success: {
+                    code: 200,
+                    result,
+                },
+            };
+            res.json(ans);
+            res.status(200);
+        })
+        .catch((e) => {
+            res.status(400).json(getBadRequestError(e));
+        });
+};
+
+exports.getProcess = getProcess;


### PR DESCRIPTION
GET /letterPairCount
パラメータ無し

```
{
  "success": {
    "code": 200,
    "result": [
      {
        "letters": "あい",
        "word": "愛",
        "userCount": 16
      }
    ]
  }
}
```