### PR TITLE
問い合わせ対応: レターペアの途中で空白を入れることを許容する

### DIFF
--- a/src/route/letterPair.js
+++ b/src/route/letterPair.js
@@ -20,7 +20,7 @@ const postProcess = (req, res, next) => {
         return;
     }
 
-    const words = inputWord.replace(/\s/g, '').split(/[,，、/／]/).filter(x => x.length > 0);
+    const words = inputWord.replace(/\s+/g, ' ').split(/[,，、/／]/).map(x => x.trim()).filter(x => x.length > 0);
     const promises = [];
     for (let i = 0; i < words.length; i++) {
         const word = words[i];


### PR DESCRIPTION
問い合わせ対応 https://github.com/sakabar/hinemos/issues/858 
https://github.com/sakabar/hinemos/pull/859 と同様のロジックがAPI側にも入っていたので、修正する。